### PR TITLE
Add missing  log level default config

### DIFF
--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <dev>
+            <log>
+                <level>ERROR</level>
+            </log>
+        </dev>
+    </default>
+</config>


### PR DESCRIPTION
When using the `\IODigital\Core\Service\Config` service in modules without setting any configuration, we receive a 500 error. This PR fixes this issue by setting `ERROR` as default configurations. I chose `ERROR` as default which is best for production environments.